### PR TITLE
Read PORT from environment variable

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
+// console.log(process.env);
 
 app.get("/", (req, res) => {
   res.send("Hello World!");


### PR DESCRIPTION
Here we see the reason why we need to save the PORT as an environment variable:
https://devcenter.heroku.com/articles/runtime-principles

![Screenshot 2020-09-03 at 10 32 43](https://user-images.githubusercontent.com/68222396/92091269-ce661b00-edd0-11ea-8c23-36f7c1023fe2.png)
